### PR TITLE
Feature/36

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
-import 'package:team14/views/memo_detail_page.dart';
 import 'package:team14/views/common_widgets.dart';
+import 'package:team14/views/select_template_page.dart';
+import 'package:team14/views/memo_list_page.dart';
+import 'package:team14/views/create_template_page.dart';
 
 void main() {
   runApp(const MyApp());
@@ -17,10 +19,11 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
-      initialRoute: '/',
+      initialRoute: '/select_template_page',
       routes: {
-        '/': (context) => const MyHomePage(title: 'Flutter Demo Home Page'),
-        '/memo_detail_page': (context) => const MemoDetailPage(),
+        '/select_template_page': (context) => const SelectTemplatePage(),
+        '/memo_list_page': (context) => const MemoListPage(),
+        '/create_template_page': (context) => const CreateTemplatePage(),
       },
     );
   }

--- a/lib/views/common_widgets.dart
+++ b/lib/views/common_widgets.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:team14/models/spotProvider.dart';
-import 'package:team14/views/memo_detail_page.dart';
 
 PreferredSizeWidget myAppBar({required title, required context}) {
   return AppBar(
@@ -57,15 +56,13 @@ Widget myDrawer(BuildContext context) {
         ListTile(
           title: const Text('メモ一覧'),
           onTap: () {
-            Navigator.of(context).push(
-              MaterialPageRoute(
-                builder: (context) {
-                  // TODO: Change the code to move to the memo list.
-                  // (This is dummy class.)
-                  return const MemoDetailPage();
-                },
-              ),
-            );
+            Navigator.pushNamed(context, '/memo_list_page');
+          },
+        ),
+        ListTile(
+          title: const Text('テンプレート一覧'),
+          onTap: () {
+            Navigator.pushNamed(context, '/select_template_page');
           },
         ),
       ],

--- a/lib/views/create_memo_page.dart
+++ b/lib/views/create_memo_page.dart
@@ -8,7 +8,12 @@ import 'package:team14/models/spot.dart';
 import 'package:team14/api/weather.dart';
 
 class CreateMemoPage extends StatefulWidget {
-  const CreateMemoPage({Key? key}) : super(key: key);
+  final int templateMemoId;
+
+  const CreateMemoPage({
+    Key? key,
+    required this.templateMemoId,
+  }) : super(key: key);
 
   @override
   State<CreateMemoPage> createState() => _CreateMemoPageState();
@@ -20,11 +25,7 @@ class _CreateMemoPageState extends State<CreateMemoPage> {
   final defaultSpotTitle = 'Memo';
 
   Future<Map<String, dynamic>> _connectDBProcess() async {
-    // Dummy data
-    /// NOTE: Receive Memo template id at screen transition.
-    const int templateMemoId = 1;
-
-    MemoTemplate? mt = await mtp.selectMemoTemplate(templateMemoId);
+    MemoTemplate? mt = await mtp.selectMemoTemplate(widget.templateMemoId);
     if (mt == null) {
       throw StateError('[${runtimeType.toString()}] Memo template id is null!');
     }
@@ -85,6 +86,9 @@ class _CreateMemoPageState extends State<CreateMemoPage> {
       spot.createdAt = spot.updatedAt = DateTime.now();
 
       await sp.insert(spot);
+      Future(() {
+        Navigator.pushNamed(context, '/memo_list_page');
+      });
     } on Exception catch (e) {
       throw Exception('$e');
     }

--- a/lib/views/create_template_page.dart
+++ b/lib/views/create_template_page.dart
@@ -411,8 +411,9 @@ class _NamingTemplateState extends State<NamingTemplate> {
         } on DatabaseException catch (_) {
           Fluttertoast.showToast(msg: '入力したテンプレート名はすでに使われています');
         }
-        // TODO
-        // メモ一覧に遷移
+        Future(() {
+          Navigator.pushNamed(context, '/select_template_page');
+        });
       }
     }
 

--- a/lib/views/detail_helper.dart
+++ b/lib/views/detail_helper.dart
@@ -28,10 +28,11 @@ Widget listItem(String leftText, String rightText) {
   );
 }
 
-List<Widget> getListWidget({required Set<dynamic> list, required String leftName}){
+List<Widget> getListWidget(
+    {required Set<dynamic> list, required String leftName}) {
   List<Widget> widgets = [];
-  for (var i = 0; i < list.length; i++){
-    widgets.add(listItem(leftName+i.toString(), list.elementAt(i)));
+  for (var i = 0; i < list.length; i++) {
+    widgets.add(listItem(leftName + i.toString(), list.elementAt(i)));
   }
   return widgets;
 }

--- a/lib/views/memo_detail_page.dart
+++ b/lib/views/memo_detail_page.dart
@@ -26,7 +26,11 @@ class _MemoDetailPageState extends State<MemoDetailPage> {
           listItem('タイトル', widget.spot.title),
           listItem('位置情報',
               '${widget.spot.gpsLatitude}, ${widget.spot.gpsLongitude}'),
-          listItem('降水量', '${widget.spot.weatherObsDate}'),
+          // Includes data on precipitation up to one hour ahead.
+          for (var i = 0; i < widget.spot.rainfallList.length; i++)
+            listItem(
+                '降水量(${widget.spot.weatherObsDate.add(Duration(minutes: 60 ~/ (widget.spot.rainfallList.length - 1) * i))})',
+                '${widget.spot.rainfallList.elementAt(i)}'),
           if (widget.memoTemplate.textBox)
             listItem('テキスト', '${widget.spot.textBox}'),
           for (var i = 0;

--- a/lib/views/memo_detail_page.dart
+++ b/lib/views/memo_detail_page.dart
@@ -5,7 +5,9 @@ import 'package:team14/models/memoTemplate.dart';
 import 'package:team14/models/spot.dart';
 
 class MemoDetailPage extends StatefulWidget {
-  const MemoDetailPage({Key? key, required this.memoTemplate, required this.spot}) : super(key: key);
+  const MemoDetailPage(
+      {Key? key, required this.memoTemplate, required this.spot})
+      : super(key: key);
 
   final MemoTemplate memoTemplate;
   final Spot spot;
@@ -15,14 +17,6 @@ class MemoDetailPage extends StatefulWidget {
 }
 
 class _MemoDetailPageState extends State<MemoDetailPage> {
-  // MemoTemplate mt = MemoTemplate(
-  //     'template',
-  //     true,
-  //     {'駐輪しやすい', '受け取り待機時間なし', '店員の態度がいい'},
-  //     {'オファー金額', '800~1000円', '1000~1200円'});
-  // Spot spot = Spot("マクドナルド 石橋店", 21.0, 34.807805, 135.444553, 1, "近くにチェーン店がある",
-  //     [true, true, true], 0, DateTime.now(), DateTime.now());
-
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -30,15 +24,21 @@ class _MemoDetailPageState extends State<MemoDetailPage> {
       body: ListView(
         children: [
           listItem('タイトル', widget.spot.title),
-          listItem('位置情報', '${widget.spot.gpsLatitude}, ${widget.spot.gpsLongitude}'),
-          listItem('気温', '${widget.spot.temperature}'),
-          if (widget.memoTemplate.textBox) listItem('テキスト', '${widget.spot.textBox}'),
-          for (var i = 0; i < widget.memoTemplate.multipleSelectList.length; i++)
+          listItem('位置情報',
+              '${widget.spot.gpsLatitude}, ${widget.spot.gpsLongitude}'),
+          listItem('降水量', '${widget.spot.weatherObsDate}'),
+          if (widget.memoTemplate.textBox)
+            listItem('テキスト', '${widget.spot.textBox}'),
+          for (var i = 0;
+              i < widget.memoTemplate.multipleSelectList.length;
+              i++)
             listItem(widget.memoTemplate.multipleSelectList.elementAt(i),
                 widget.spot.multipleSelectList![i] ? 'はい' : 'いいえ'),
           if (widget.memoTemplate.singleSelectList.isNotEmpty)
-            listItem(widget.memoTemplate.singleSelectList.first,
-                widget.memoTemplate.singleSelectList.elementAt(widget.spot.singleSelect! + 1)),
+            listItem(
+                widget.memoTemplate.singleSelectList.first,
+                widget.memoTemplate.singleSelectList
+                    .elementAt(widget.spot.singleSelect!)),
         ],
       ),
       drawer: myDrawer(context),

--- a/lib/views/memo_detail_page.dart
+++ b/lib/views/memo_detail_page.dart
@@ -5,9 +5,11 @@ import 'package:team14/models/memoTemplate.dart';
 import 'package:team14/models/spot.dart';
 
 class MemoDetailPage extends StatefulWidget {
-  const MemoDetailPage(
-      {Key? key, required this.memoTemplate, required this.spot})
-      : super(key: key);
+  const MemoDetailPage({
+    Key? key,
+    required this.memoTemplate,
+    required this.spot,
+  }) : super(key: key);
 
   final MemoTemplate memoTemplate;
   final Spot spot;

--- a/lib/views/memo_list_page.dart
+++ b/lib/views/memo_list_page.dart
@@ -1,7 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:team14/views/common_widgets.dart';
 import 'package:team14/views/list_helper.dart';
+import 'package:team14/views/memo_detail_page.dart';
+import 'package:team14/models/memoTemplate.dart';
 import 'package:team14/models/spot.dart';
+import 'package:team14/models/memoTemplateProvider.dart';
 import 'package:team14/models/spotProvider.dart';
 
 class MemoListPage extends StatefulWidget {
@@ -21,9 +24,18 @@ class _MemoListPageState extends State<MemoListPage> {
     memoList = sp.selectAll();
   }
 
-  void onTapContent() {
-    // TODO
-    // メモ詳細に遷移
+  Future<void> onTapContent(Spot spot) async {
+    MemoTemplateProvider mtp = MemoTemplateProvider();
+    MemoTemplate mt = (await mtp.selectMemoTemplate(spot.memoTemplateId))!;
+    Future(() {
+      Navigator.of(context).push(
+        MaterialPageRoute(
+          builder: (context) {
+            return MemoDetailPage(memoTemplate: mt, spot: spot);
+          },
+        ),
+      );
+    });
   }
 
   // Delete memo, update memoList
@@ -40,7 +52,7 @@ class _MemoListPageState extends State<MemoListPage> {
       appBar: myAppBar(title: 'メモ一覧', context: context),
       floatingActionButton: FloatingActionButton(
         onPressed: () {
-          // TODO
+          // FIXME: メモテンプレートのIDが保存されていないので，遷移不可能
           // メモ作成画面に遷移
         },
         child: const Icon(Icons.add),
@@ -69,7 +81,9 @@ class _MemoListPageState extends State<MemoListPage> {
                         itemBuilder: (context, index) {
                           return Card(
                             child: ListTile(
-                              onTap: onTapContent,
+                              onTap: () {
+                                onTapContent(snapshot.data!.elementAt(index));
+                              },
                               leading: const Icon(Icons.description),
                               title: Text(snapshot.data![index].title),
                               trailing: IconButton(

--- a/lib/views/select_template_page.dart
+++ b/lib/views/select_template_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:team14/views/common_widgets.dart';
 import 'package:team14/views/list_helper.dart';
+import 'package:team14/views/create_memo_page.dart';
 import 'package:team14/models/memoTemplate.dart';
 import 'package:team14/models/memoTemplateProvider.dart';
 
@@ -21,7 +22,7 @@ class _SelectTemplatePageState extends State<SelectTemplatePage> {
     templateList = mtp.selectAll();
   }
 
-  Future<void> onTapContent() async {
+  Future<void> onTapContent(int index) async {
     var isCreateMemo = await showDialog(
       context: context,
       builder: (_) {
@@ -29,8 +30,15 @@ class _SelectTemplatePageState extends State<SelectTemplatePage> {
       },
     );
     if (isCreateMemo) {
-      // TODO
-      // メモ作成画面に遷移
+      return Future(() {
+        Navigator.of(context).push(
+          MaterialPageRoute(
+            builder: (context) {
+              return CreateMemoPage(templateMemoId: index);
+            },
+          ),
+        );
+      });
     }
   }
 
@@ -48,8 +56,7 @@ class _SelectTemplatePageState extends State<SelectTemplatePage> {
       appBar: myAppBar(title: 'テンプレート選択', context: context),
       floatingActionButton: FloatingActionButton(
         onPressed: () {
-          // TODO
-          // メモテンプレ作成画面に遷移
+          Navigator.pushNamed(context, '/create_template_page');
         },
         child: const Icon(Icons.add),
       ),
@@ -65,19 +72,27 @@ class _SelectTemplatePageState extends State<SelectTemplatePage> {
                   BuildContext context,
                   AsyncSnapshot<List<MemoTemplate>> snapshot,
                 ) {
-                  if (snapshot.hasData == false) {
-                    return const Center(
-                      child: Text('テンプレートがありません'),
-                    );
+                  if (snapshot.data == null) {
+                    // Fetching data from DB.
+                    return const Center(child: CircularProgressIndicator());
+                  } else if (snapshot.data!.isEmpty) {
+                    // Nothing Template.
+                    Future(() {
+                      Navigator.pushNamed(context, '/create_template_page');
+                    });
+                    return const Center(child: CircularProgressIndicator());
                   } else {
-                    // DBにデータがある場合
+                    // Found Template.
                     if (snapshot.data!.isNotEmpty) {
                       return ListView.builder(
                         itemCount: snapshot.data!.length,
                         itemBuilder: (context, index) {
                           return Card(
                             child: ListTile(
-                              onTap: onTapContent,
+                              onTap: () {
+                                onTapContent(
+                                    snapshot.data!.elementAt(index).id!);
+                              },
                               leading: const Icon(Icons.square_outlined),
                               title: Text(snapshot.data![index].name),
                               trailing: IconButton(

--- a/lib/views/template_detail_page.dart
+++ b/lib/views/template_detail_page.dart
@@ -4,8 +4,10 @@ import 'package:team14/views/detail_helper.dart';
 import 'package:team14/models/memoTemplate.dart';
 
 class TemplateDetailPage extends StatefulWidget {
-  const TemplateDetailPage({Key? key, required this.memoTemplate})
-      : super(key: key);
+  const TemplateDetailPage({
+    Key? key,
+    required this.memoTemplate,
+  }) : super(key: key);
 
   final String title = 'テンプレート詳細';
 

--- a/lib/views/template_detail_page.dart
+++ b/lib/views/template_detail_page.dart
@@ -4,7 +4,8 @@ import 'package:team14/views/detail_helper.dart';
 import 'package:team14/models/memoTemplate.dart';
 
 class TemplateDetailPage extends StatefulWidget {
-  const TemplateDetailPage({Key? key, required this.memoTemplate}) : super(key: key);
+  const TemplateDetailPage({Key? key, required this.memoTemplate})
+      : super(key: key);
 
   final String title = 'テンプレート詳細';
 
@@ -15,7 +16,6 @@ class TemplateDetailPage extends StatefulWidget {
 }
 
 class _TemplateDetailPageState extends State<TemplateDetailPage> {
-
   Widget createListView({required list}) {
     List<Widget> widgets = [
       listItem('テンプレート名', list.name),


### PR DESCRIPTION
#36 

とりあえず，最低限の動作はするはずです．（ドロワーに，テンプレ選択画面への遷移を作りました）
* テンプレ作成
* メモ作成
* メモ一覧
* テンプレ選択
* メモ詳細
* csvで吐く

ただ，既知のバグもあります．
* メモ一覧からの+ボタンからは，メモは書けない(テンプレを選択していないから)
* メモの編集画面への遷移がない(アイコンを用意していない)
* テンプレの詳細への遷移がない(アイコンを用意していない)
* 位置情報の取得処理が未実装
* AppBarのタイトル位置
* トグルスイッチを選ばないとき，空白のトグルスイッチが発生

ページ遷移ですが，コレといったやり方がわからず，統一されていないです．
* 引数のない画面用のクラスは，`main`でルートを定義
  * SelectTemplatePage
  * MemoListPage
  * CreateTemplatePage
* 引数なしのとき，以下のように遷移
```dart
 Navigator.pushNamed(context, '/memo_list_page');
```
* 引数ありのとき，
```dart
Navigator.of(context).push(
          MaterialPageRoute(
            builder: (context) {
              return CreateMemoPage(templateMemoId: index);
            },
          ),
        );
```
* 非同期処理を含む場合，`Future`でラップ

そもそも，遷移の仕方として，やり方合っているのでしょうか．．．？