### PR TITLE
2回目のアプリ起動時にメモ作成画面に遷移するように変更

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:team14/views/common_widgets.dart';
 import 'package:team14/views/select_template_page.dart';
 import 'package:team14/views/memo_list_page.dart';
 import 'package:team14/views/create_template_page.dart';
+import 'package:team14/views/create_memo_page.dart';
 
 void main() {
   runApp(const MyApp());
@@ -19,11 +20,12 @@ class MyApp extends StatelessWidget {
       theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
-      initialRoute: '/select_template_page',
+      initialRoute: '/create_memo_page',
       routes: {
         '/select_template_page': (context) => const SelectTemplatePage(),
         '/memo_list_page': (context) => const MemoListPage(),
         '/create_template_page': (context) => const CreateTemplatePage(),
+        '/create_memo_page': (context) => const CreateMemoPage(),
       },
     );
   }

--- a/lib/views/create_memo_page.dart
+++ b/lib/views/create_memo_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:team14/views/memo_form_helper.dart';
+import 'package:team14/models/defaultTemplateProvider.dart';
 import 'package:team14/models/memoTemplateProvider.dart';
 import 'package:team14/models/memoProvider.dart';
 import 'package:team14/models/memoTemplate.dart';
@@ -8,12 +9,7 @@ import 'package:team14/models/memo.dart';
 import 'package:team14/api/weather.dart';
 
 class CreateMemoPage extends StatefulWidget {
-  final int templateMemoId;
-
-  const CreateMemoPage({
-    Key? key,
-    required this.templateMemoId,
-  }) : super(key: key);
+  const CreateMemoPage({Key? key}) : super(key: key);
 
   @override
   State<CreateMemoPage> createState() => _CreateMemoPageState();
@@ -25,7 +21,18 @@ class _CreateMemoPageState extends State<CreateMemoPage> {
   final defaultMemoTitle = 'Memo';
 
   Future<Map<String, dynamic>> _connectDBProcess() async {
-    MemoTemplate? mt = await mtp.selectMemoTemplate(widget.templateMemoId);
+    final int? templateMemoId =
+        await DefaultTemplateProvider().getDefaultTemplateId();
+
+    if (templateMemoId == null) {
+      // NOTE: デフォルトのテンプレートidが登録されていない場合，
+      // 'create_template_page'に遷移する必要がある.
+      // 'memo_form_helper'のFutureBuilder内のifで，
+      // 空のmapが渡されたときに遷移するような処理を構築している.
+      return {};
+    }
+
+    MemoTemplate? mt = await mtp.selectMemoTemplate(templateMemoId);
     if (mt == null) {
       throw StateError('[${runtimeType.toString()}] Memo template id is null!');
     }

--- a/lib/views/memo_form_helper.dart
+++ b/lib/views/memo_form_helper.dart
@@ -138,6 +138,12 @@ class _MemoFormHelperState extends State<MemoFormHelper> {
               AsyncSnapshot<Map<String, dynamic>> snapshot) {
             if (snapshot.data == null) {
               return const Center(child: CircularProgressIndicator());
+            } else if (snapshot.data!.isEmpty) {
+              // When the default template id is not registered.
+              Future(() {
+                Navigator.pushNamed(context, '/create_template_page');
+              });
+              return const Center(child: CircularProgressIndicator());
             } else {
               _initializeAsyncValues(snapshot.data!);
               return _contentWidget();

--- a/lib/views/memo_list_page.dart
+++ b/lib/views/memo_list_page.dart
@@ -8,9 +8,6 @@ import 'package:team14/models/memoTemplate.dart';
 import 'package:team14/models/memo.dart';
 import 'package:team14/models/memoTemplateProvider.dart';
 import 'package:team14/models/memoProvider.dart';
-import 'package:team14/models/defaultTemplateProvider.dart';
-
-import 'create_memo_page.dart';
 
 class MemoListPage extends StatefulWidget {
   const MemoListPage({Key? key}) : super(key: key);
@@ -22,9 +19,6 @@ class MemoListPage extends StatefulWidget {
 class _MemoListPageState extends State<MemoListPage> {
   late Future<List<Memo>> memoList;
   late MemoProvider mp = MemoProvider();
-
-  // テンプレid
-  DefaultTemplateProvider dtp = DefaultTemplateProvider();
 
   @override
   void initState() {
@@ -61,22 +55,9 @@ class _MemoListPageState extends State<MemoListPage> {
       floatingActionButton: FloatingActionButton(
         onPressed: () async {
           // メモ作成画面に遷移
-          var defaultTemplate = await dtp.getDefaultTemplateId();
-          if (defaultTemplate != null) {
-            Future(() {
-              Navigator.of(context).push(
-                MaterialPageRoute(
-                  builder: (context) {
-                    return CreateMemoPage(templateMemoId: defaultTemplate);
-                  },
-                ),
-              );
-            });
-          } else {
-            Future(() {
-              Navigator.pushNamed(context, '/create_template_page');
-            });
-          }
+          Future(() {
+            Navigator.pushNamed(context, '/create_memo_page');
+          });
         },
         child: const Icon(Icons.add),
       ),


### PR DESCRIPTION
#69 
`メモ作成画面`でテンプレidが登録されているか確認
* 未登録なら`テンプレ作成画面`に遷移
* メモリスト画面では，その判断を行わないように変更
* つまり，一旦`メモ作成画面`に遷移する